### PR TITLE
feat: parse EventBrite dot format seen on eventbrite.com pages.

### DIFF
--- a/src/trouver_une_fresque_scraper/apis/ics.py
+++ b/src/trouver_une_fresque_scraper/apis/ics.py
@@ -128,7 +128,13 @@ def get_ics_data(source):
         ################################################################
         # Override workshop type if specified in the event
         ################################################################
-        workshop_id = get_suffix_from_strings(event.categories, "Workshop ID: ")
+        # Google Calendar concatenates categories with commas when importing
+        # from ICS files, so split again here.
+        categories = set()
+        for category in event.categories:
+            for c in category.split(","):
+                categories.add(c)
+        workshop_id = get_suffix_from_strings(categories, "Workshop ID: ")
         if workshop_id:
             workshop_id = int(workshop_id)
             if workshop_id == 0:
@@ -199,10 +205,12 @@ def get_ics_data(source):
         # Get language from registry, override or language code detection.
         ################################################################
         language_code = source.get(
-            "language_code", get_suffix_from_strings(event.categories, "Language: ")
+            "language_code", get_suffix_from_strings(categories, "Language: ")
         )
         if language_code is None:
             language_code = detect_language_code(title, description)
+        if language_code:
+            language_code = language_code.lower()
 
         ################################################################
         # Building final object

--- a/src/trouver_une_fresque_scraper/scraper/billetweb.py
+++ b/src/trouver_une_fresque_scraper/scraper/billetweb.py
@@ -247,9 +247,9 @@ def get_billetweb_data(sources, service, options):
                 ################################################################
                 # Location data
                 ################################################################
-                location_name = (
-                    address
-                ) = city = department = longitude = latitude = zip_code = country_code = ""
+                location_name = address = city = department = longitude = latitude = zip_code = (
+                    country_code
+                ) = ""
                 if not online:
                     try:
                         address_dict = get_address(full_location)

--- a/src/trouver_une_fresque_scraper/scraper/eventbrite.py
+++ b/src/trouver_une_fresque_scraper/scraper/eventbrite.py
@@ -126,7 +126,7 @@ def get_eventbrite_data(sources, service=None, options=None):
     Returns:
         List of event records
     """
-    logging.info("Scraping data from eventbrite.fr")
+    logging.info("Scraping data from eventbrite.com or eventbrite.fr")
 
     headless = False
     if options and hasattr(options, "arguments") and len(options.arguments) > 0:

--- a/src/trouver_une_fresque_scraper/scraper/main.py
+++ b/src/trouver_une_fresque_scraper/scraper/main.py
@@ -14,6 +14,7 @@ from trouver_une_fresque_scraper.utils.utils import get_config
 SCRAPER_FNS = {
     "billetweb.fr": get_billetweb_data,
     "climatefresk.org": get_fdc_data,
+    "eventbrite.com": get_eventbrite_data,
     "eventbrite.fr": get_eventbrite_data,
     "fresqueduclimat.org": get_fdc_data,
     "lafresquedeleconomiecirculaire.com": get_fec_data,

--- a/src/trouver_une_fresque_scraper/utils/date_and_time.py
+++ b/src/trouver_une_fresque_scraper/utils/date_and_time.py
@@ -64,6 +64,31 @@ FRENCH_MONTHS = {
     "décembre": 12,
 }
 
+ENGLISH_DAYS = {
+    "monday": 1,
+    "tuesday": 2,
+    "wednesday": 3,
+    "thursday": 4,
+    "friday": 5,
+    "saturday": 6,
+    "sunday": 7,
+}
+
+ENGLISH_MONTHS = {
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "april": 4,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "september": 9,
+    "october": 10,
+    "november": 11,
+    "december": 12,
+}
+
 
 def get_dates(event_time):
     try:
@@ -264,6 +289,42 @@ def get_dates(event_time):
             date_str = f"{year}-{month_num:02d}-{day:02d}"
             event_start_datetime = parse(f"{date_str} {match.group('start_time')}")
             event_end_datetime = parse(f"{date_str} {match.group('end_time')}")
+
+            return event_start_datetime, event_end_datetime
+
+        # ===================
+        # Eventbrite dot format
+
+        # Tuesday 9 June  •  17:30 - 21
+        elif match := re.match(
+            rf"(?P<day_of_week>{'|'.join(ENGLISH_DAYS.keys())})\s"
+            r"(?P<day>\d{1,2})\s"
+            rf"(?P<month>{'|'.join(ENGLISH_MONTHS.keys())})\s+"
+            r"\S\s+"
+            r"(?P<start_hour>\d{1,2})(:(?P<start_minute>\d{2}))?\s"
+            r"\-\s"
+            r"(?P<end_hour>\d{1,2})(:(?P<end_minute>\d{2}))?",
+            event_time,
+            re.IGNORECASE,
+        ):
+            month_num = ENGLISH_MONTHS.get(match.group("month").lower())
+            day = int(match.group("day"))
+
+            # Assume current year, or next year if month/day are already past.
+            current_date = datetime.now()
+            year = current_date.year
+            temp_date = datetime(year, month_num, day)
+            if temp_date < current_date:
+                year += 1
+
+            # Build date string and parse with times
+            date_str = f"{year}-{month_num:02d}-{day:02d}"
+            start_hour = int(match.group("start_hour"))
+            start_minute = int(match.group("start_minute")) if match.group("start_minute") else 0
+            end_hour = int(match.group("end_hour"))
+            end_minute = int(match.group("end_minute")) if match.group("end_minute") else 0
+            event_start_datetime = parse(f"{date_str} {start_hour:02d}:{start_minute:02d}")
+            event_end_datetime = parse(f"{date_str} {end_hour:02d}:{end_minute:02d}")
 
             return event_start_datetime, event_end_datetime
 

--- a/src/trouver_une_fresque_scraper/utils/date_and_time_test.py
+++ b/src/trouver_une_fresque_scraper/utils/date_and_time_test.py
@@ -76,14 +76,14 @@ def run_get_dates_tests():
         (
             "Eventbrite collection modal mixed French/English: afternoon",
             "janv. 24 de 2pm à 5:30pm UTC+1",
-            datetime(2026, 1, 24, 14, 0),
-            datetime(2026, 1, 24, 17, 30),
+            datetime(2027, 1, 24, 14, 0),
+            datetime(2027, 1, 24, 17, 30),
         ),
         (
             "Eventbrite collection modal mixed French/English: morning",
             "févr. 15 de 9am à 12:30pm UTC+1",
-            datetime(2026, 2, 15, 9, 0),
-            datetime(2026, 2, 15, 12, 30),
+            datetime(2027, 2, 15, 9, 0),
+            datetime(2027, 2, 15, 12, 30),
         ),
         (
             "Eventbrite event-datetime format: evening",
@@ -171,6 +171,20 @@ def run_get_dates_from_element_tests():
             "janv. 21 de 9am à 12:30pm UTC+1",
             datetime(2026, 1, 21, 9, 0),
             datetime(2026, 1, 21, 12, 30),
+        ),
+        (
+            "EventBrite: dot format, start time with no minutes",
+            "2026-06-09",
+            "Thursday 21 May  •  18 - 21:30",
+            datetime(2026, 5, 21, 18, 0),
+            datetime(2026, 5, 21, 21, 30),
+        ),
+        (
+            "EventBrite: dot format, end time with no minutes",
+            "2026-06-09",
+            "Tuesday 9 June  •  17:30 - 21",
+            datetime(2026, 6, 9, 17, 30),
+            datetime(2026, 6, 9, 21, 0),
         ),
     ]
     for test_case in test_cases:


### PR DESCRIPTION
2tonnes international is on an eventbrite.com page rather than eventbrite.fr. Dates are displayed with the format "Tuesday 9 June  •  17:30 - 21".

These changes enable fetching 2tonnes events in Switzerland.